### PR TITLE
Optional cert validation

### DIFF
--- a/yaml/sc4otel.yaml
+++ b/yaml/sc4otel.yaml
@@ -538,8 +538,8 @@ clusterReceiver:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
   k8sObjects:
     - name: pods
-    mode: pull
-    interval: 15m
+      mode: pull
+      interval: 15m
 
   # k8s cluster receiver extra pod labels
   podLabels: {}

--- a/yaml/sc4otel.yaml
+++ b/yaml/sc4otel.yaml
@@ -438,7 +438,10 @@ agent:
   # Default configuration defined in templates/config/_otel-agent.tpl
   # Any additional fields will be merged into the defaults,
   # existing fields can be disabled by setting them to null value.
-  config: {}
+  config:
+    receivers:
+      kubeletstats:
+        insecure_skip_verify: false
 
   # Discovery mode attempts to automatically configure the agent with bundled metric receiver configuration.
   # For more details, refer to: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#discovery-mode


### PR DESCRIPTION
Add configurations to address #8 and allow for certification validation disablement of kubeletstats receiver errors in **splunk-otel-collector-sc4otel-agent** pod logs.

This PR includes changes from #7 to prevent code reversion and should be merged after that PR has been approved/merged.